### PR TITLE
Stop iteration when file is found

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -153,6 +153,7 @@ class Chromium {
       for (let file of readdirSync(input)) {
         if (file.startsWith('chromium-') === true) {
           input = `${input}/${file}`;
+          break;
         }
       }
 


### PR DESCRIPTION
Fixes `ENOTDIR: not a directory, open '/var/task/node_modules/chrome-aws-lambda/source/../bin/chromium-72.0.3617.0.br/chromium-74.0.3723.0.br` error