### PR TITLE
Include nodejs10.x.zip inside the npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "typings": "source/index.d.ts",
   "files": [
     "bin",
-    "source"
+    "source",
+    "_/nodejs10.x.zip"
   ],
   "engines": {
     "node": ">= 8.10"


### PR DESCRIPTION
include the nodejs10.x.zip in the npm tarball for easier integration as serverless fw layer artifact

https://github.com/alixaxel/chrome-aws-lambda/issues/37#issuecomment-540251030