### PR TITLE
re-enable proprietary_codecs to allow H.264 decoding

### DIFF
--- a/_/ansible/plays/chromium.yml
+++ b/_/ansible/plays/chromium.yml
@@ -237,10 +237,12 @@
           enable_media_remoting_rpc = false
           enable_nacl = false
           enable_one_click_signin = false
+          ffmpeg_branding = "Chrome"
           headless_use_embedded_resources = true
           icu_use_data_file = false
           is_component_build = false
           is_debug = false
+          proprietary_codecs = true
           symbol_level = 0
           target_cpu = "x64"
           target_os = "linux"


### PR DESCRIPTION
This was disable in https://github.com/alixaxel/chrome-aws-lambda/issues/39 due to video tags not working. Even though the video tag might not work, enabling `proprietary_codecs` allows chrome to decode mp4/H.264 and render them to a canvas.

We've been running a fork using this method without any issues, would be great to get it turned back on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alixaxel/chrome-aws-lambda/68)
<!-- Reviewable:end -->
