### PR TITLE
Fix for file or directory not found

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -1,4 +1,5 @@
 const { createWriteStream, existsSync, mkdirSync, readdirSync, unlinkSync } = require('fs');
+const { join } = require('path');
 const { get } = require('https');
 const { inflate } = require('lambdafs');
 const { URL } = require('url');
@@ -158,7 +159,7 @@ class Chromium {
       return Promise.resolve('/tmp/chromium');
     }
 
-    let input = `${__dirname}/../bin`;
+    const input = join(__dirname, '..', 'bin');
     let promises = [
       inflate(`${input}/chromium.br`),
       inflate(`${input}/swiftshader.tar.br`),


### PR DESCRIPTION
Use `join` to build path to compressed files.

[Issue](https://github.com/alixaxel/chrome-aws-lambda/issues/80)