### PR TITLE
Bugfix: Don't expect LD_LIBRARY_PATH to be always a string.

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -9,7 +9,9 @@ if (['AWS_Lambda_nodejs10.x', 'AWS_Lambda_nodejs12.x'].includes(process.env.AWS_
     process.env.FONTCONFIG_PATH = '/tmp/aws';
   }
 
-  if (process.env.LD_LIBRARY_PATH.startsWith('/tmp/aws/lib') !== true) {
+  if (!process.env.LD_LIBRARY_PATH) {
+    process.env.LD_LIBRARY_PATH = '/tmp/aws/lib';
+  } else if (process.env.LD_LIBRARY_PATH.startsWith('/tmp/aws/lib') !== true) {
     process.env.LD_LIBRARY_PATH = [...new Set(['/tmp/aws/lib', ...process.env.LD_LIBRARY_PATH.split(':')])].join(':');
   }
 }


### PR DESCRIPTION
In some environments (e.g. AWS_ECS_EC2) process.env.LD_LIBRARY_PATH can be undefined yielding the following error:

```
  if (process.env.LD_LIBRARY_PATH.startsWith('/tmp/aws/lib') !== true) {
                                  ^

TypeError: Cannot read property 'startsWith' of undefined
```

This commit fixes the issue by ensuring that LD_LIBRARY_PATH set.