### PR TITLE
chore: improve typescript typings

### DIFF
--- a/source/index.d.ts
+++ b/source/index.d.ts
@@ -14,12 +14,4 @@ export const defaultViewport: {
 
 export const executablePath: Promise<string>;
 export const headless: boolean;
-export const puppeteer: {
-  connect(options?: ConnectOptions): Promise<Browser>;
-  createBrowserFetcher(options?: FetcherOptions): BrowserFetcher;
-  defaultArgs(options?: ChromeArgOptions): string[];
-  devices: any;
-  errors: any;
-  executablePath(): string;
-  launch(options?: LaunchOptions): Promise<Browser>;
-};
+export const puppeteer: typeof import('puppeteer');


### PR DESCRIPTION
Improves & simplifies the typescript typings by using the type of `puppeteer` directly.

This means that the types will always be accurate, as they'll be coming from the same types that would be used for native puppeteer.