### PR TITLE
feat: add methods to typings

### DIFF
--- a/source/index.d.ts
+++ b/source/index.d.ts
@@ -1,17 +1,20 @@
 import { Browser, BrowserFetcher, ChromeArgOptions, ConnectOptions, FetcherOptions, LaunchOptions } from 'puppeteer';
 
-export const font: (input: string) => Promise<string>;
+declare class Chromium {
+  static font(input: string): Promise<string>;
+  static get args(): string[]
+  static get defaultViewport(): {
+    deviceScaleFactor: number;
+    hasTouch: boolean;
+    height: number;
+    isLandscape: boolean;
+    isMobile: boolean;
+    width: number;
+  }
 
-export const args: string[];
-export const defaultViewport: {
-  deviceScaleFactor: number;
-  hasTouch: boolean;
-  height: number;
-  isLandscape: boolean;
-  isMobile: boolean;
-  width: number;
-};
+  static get executablePath(): Promise<string>
+  static get headless(): boolean;
+  static get puppeteer(): typeof import('puppeteer');
+}
 
-export const executablePath: Promise<string>;
-export const headless: boolean;
-export const puppeteer: typeof import('puppeteer');
+export = Chromium;

--- a/source/index.d.ts
+++ b/source/index.d.ts
@@ -1,4 +1,36 @@
-import { Browser, BrowserFetcher, ChromeArgOptions, ConnectOptions, FetcherOptions, LaunchOptions } from 'puppeteer';
+import {
+  Browser,
+  BrowserFetcher,
+  ChromeArgOptions,
+  ConnectOptions,
+  ElementHandle,
+  FetcherOptions,
+  LaunchOptions,
+  NavigationOptions,
+  Response,
+} from 'puppeteer';
+
+declare namespace Chromium {
+  export interface CommonExtraFunctions {
+    count: (selector: string) => unknown;
+    exists: (selector: string) => unknown;
+    fill: (form: unknown, data: unknown, heuristic?: string) => unknown;
+    number: (selector: string, decimal?: number | null, index?: number | null, property?: string) => unknown;
+    selectByLabel: (selector: string, ...values: unknown[]) => unknown;
+    string: (selector: string, property?: string) => unknown;
+    waitUntilVisible: (selector: string, timeout?: number | null) => Promise<ElementHandle>;
+    waitWhileVisible: (selector: string, timeout?: number | null) => Promise<ElementHandle>;
+  }
+
+  export interface σ {
+    $: (selector: string, context?: unknown) => void;
+    $$: (selector: string, index?: number | null, context?: unknown) => void;
+    $x: (expression: unknown, index?: number | null, context?: unknown) => void;
+    $number: (data: unknown, decimal?: number | null, index?: number | null, property?: string) => void;
+    $string: (data: unknown, property?: string) => void;
+    $regexp: (data: unknown, pattern: RegExp, index?: number | null, property?: string) => void;
+  }
+}
 
 declare class Chromium {
   static font(input: string): Promise<string>;
@@ -18,3 +50,18 @@ declare class Chromium {
 }
 
 export = Chromium;
+
+declare global {
+  export interface Window {
+    σ: Chromium.σ
+  }
+}
+
+declare module 'puppeteer' {
+  export interface Page extends Chromium.CommonExtraFunctions {
+    clickAndWaitForNavigation: (selector: unknown, options?: NavigationOptions) => Promise<Response>;
+    go: (url: unknown, options?: unknown | null) => unknown;
+  }
+
+  export interface Frame extends Chromium.CommonExtraFunctions {}
+}


### PR DESCRIPTION
fixes #122
fixes #114

Note that you need to import from `chrome-aws-lambda`, i.e

```
import { launchBrowser } from '@src/utils';

interface TakeScreenshotOptions {
  fullPage?: boolean;
  width?: number;
  height?: number;
}

const takeScreenshot = async (
  url: string,
  options: TakeScreenshotOptions = {}
): Promise<Buffer> => {
  const browser = await launchBrowser(options);

  try {
    const page = await browser.newPage();

    await page.goto(url);
    
     // TS error: count doesn't exist
    await page.count(/* args */);

    return await page.screenshot({ fullPage: options.fullPage });
  } finally {
    await browser.close();
  }
};
```

You can resolve this error by adding `import 'chrome-aws-lambda';`