### PR TITLE
fix: use correct export syntax in typings

### DIFF
--- a/source/index.d.ts
+++ b/source/index.d.ts
@@ -1,17 +1,20 @@
 import { Browser, BrowserFetcher, ChromeArgOptions, ConnectOptions, FetcherOptions, LaunchOptions } from 'puppeteer';
 
-export const font: (input: string) => Promise<string>;
+declare class Chromium {
+  static font(input: string): Promise<string>;
+  static get args(): string[]
+  static get defaultViewport(): {
+    deviceScaleFactor: number;
+    hasTouch: boolean;
+    height: number;
+    isLandscape: boolean;
+    isMobile: boolean;
+    width: number;
+  }
 
-export const args: string[];
-export const defaultViewport: {
-  deviceScaleFactor: number;
-  hasTouch: boolean;
-  height: number;
-  isLandscape: boolean;
-  isMobile: boolean;
-  width: number;
-};
+  static get executablePath(): Promise<string>
+  static get headless(): boolean;
+  static get puppeteer(): typeof import('puppeteer');
+}
 
-export const executablePath: Promise<string>;
-export const headless: boolean;
-export const puppeteer: typeof import('puppeteer');
+export = Chromium;


### PR DESCRIPTION
This should be merged before #126.

Also to export things like the interfaces, they'll need to be wrapped in a namespace: 

```
declare namespace Chromium {
   ...
}
```

-------

In TS `module.exports` syntax is represented by `export =`.

The current typings will work fine if you use the default import syntax, but will fail *at runtime* if you use star/namespace syntax.

By using the proper export syntax, doing `import * as chromium from 'chrome-aws-lambda';` will result in an error:

> TS2497: This module can only be referenced with ECMAScript imports/exports by turning on the 'esModuleInterop' flag and referencing its default export.
