### PR TITLE
Add firebase emulator for local development

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -184,7 +184,7 @@ class Chromium {
       return false;
     }
 
-    return ['AWS_LAMBDA_FUNCTION_NAME', 'FUNCTION_NAME', 'FUNCTION_TARGET'].some((key) => process.env[key] !== undefined);
+    return ['AWS_LAMBDA_FUNCTION_NAME', 'FUNCTION_NAME', 'FUNCTION_TARGET', 'FUNCTIONS_EMULATOR'].some((key) => process.env[key] !== undefined);
   }
 
   /**


### PR DESCRIPTION
Adding this environment variable allows triggering headless mode within functions emulator by default.

This works for firebase function emulator