### PR TITLE
Fix require path for puppeteer-core 5.2.x

### DIFF
--- a/source/puppeteer/lib/Browser.js
+++ b/source/puppeteer/lib/Browser.js
@@ -3,7 +3,7 @@ let Super = null;
 try {
   Super = require('puppeteer/lib/cjs/puppeteer/common/Browser').BrowserContext;
 } catch (error) {
-  Super = require('puppeteer-core/lib/cjs/common/Browser').BrowserContext;
+  Super = require('puppeteer-core/lib/cjs/puppeteer/common/Browser').BrowserContext;
 }
 
 let newPage = Super.prototype.newPage;

--- a/source/puppeteer/lib/FrameManager.js
+++ b/source/puppeteer/lib/FrameManager.js
@@ -3,7 +3,7 @@ let Super = null;
 try {
   Super = require('puppeteer/lib/cjs/puppeteer/common/FrameManager').Frame;
 } catch (error) {
-  Super = require('puppeteer-core/lib/cjs/common/FrameManager').Frame;
+  Super = require('puppeteer-core/lib/cjs/puppeteer/common/FrameManager').Frame;
 }
 
 /**

--- a/source/puppeteer/lib/Page.js
+++ b/source/puppeteer/lib/Page.js
@@ -3,7 +3,7 @@ let Super = null;
 try {
   Super = require('puppeteer/lib/cjs/puppeteer/common/Page').Page;
 } catch (error) {
-  Super = require('puppeteer-core/lib/cjs/common/Page').Page;
+  Super = require('puppeteer-core/lib/cjs/puppeteer/common/Page').Page;
 }
 
 /**


### PR DESCRIPTION
Fixes #154 .
It was already handled for puppeteer full version with commit f4d1fed53f0a20782900483b7c11539ba13faad9, but the path for puppeteer-core was not fixed.