### PR TITLE
Allow using BrowserContext in Lambda

### DIFF
--- a/_/ansible/plays/chromium.yml
+++ b/_/ansible/plays/chromium.yml
@@ -271,6 +271,9 @@
         backrefs: yes
       with_items:
         - { path: 'content/browser/sandbox_ipc_linux.cc', regexp: '^(\s+)PLOG[(]WARNING[)] << "poll";$', line: '\1PLOG(WARNING) << "poll"; failed_polls = 0;' }
+        - { path: 'content/browser/renderer_host/render_process_host_impl.cc', regexp: '^(\s+)CHECK\(render_process_host->InSameStoragePartition\($', line: '\1' }
+        - { path: 'content/browser/renderer_host/render_process_host_impl.cc', regexp: '^(\s+)BrowserContext::GetStoragePartition\(browser_context, site_instance,$', line: '\1' }
+        - { path: 'content/browser/renderer_host/render_process_host_impl.cc', regexp: '^(\s+)false \/\* can_create \*\/\)\)\);$', line: '\1' }
 
     - name: Creating Build Configuration Directory
       file:


### PR DESCRIPTION
## Description
Allow using BrowserContext while running the Puppeteer tests in AWS Lambda

## Current Behavior
The Chromium crashes while running the test that is trying to create a new browser context.

### Test example
```js
const puppeteerCore = require('puppeteer-core');
const { args, executablePath } = require('chrome-aws-lambda');

(async () => {
  const browserExePath = await executablePath;
  const launchOptions = {
    args,
    executablePath: browserExePath,
    headless: true,
  };
  const browser = await puppeteerCore.launch(launchOptions);

  const page1 = await browser.newPage();
  await page1.goto("http://google.com");

  const context = await browser.createIncognitoBrowserContext();
  const page2 = await context.newPage();
  await page2.goto('http://example.com');

  await browser.close();
})();
```

### Chromium Error
```
[1230/101712.311672:FATAL:render_process_host_impl.cc(4507)] Check failed: render_process_host->InSameStoragePartition( BrowserContext::GetStoragePartition(browser_context, site_instance, false )).
```

## What the PR Does:
Patches the Chromium by removing lines in [render_process_host_impl.cc](https://github.com/chromium/chromium/blob/d0c2fd8409ba2387d37255f653fc4fcae0389384/content/browser/renderer_host/render_process_host_impl.cc#L4370-L4372) that disables the verification


**Inspired by** https://github.com/microsoft/playwright/issues/1379