### PR TITLE
Rename chromium args ignore-gpu-blacklist to ignore-gpu-blocklist

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -107,7 +107,7 @@ class Chromium {
       '--disable-sync',
       '--disk-cache-size=33554432',
       '--hide-scrollbars',
-      '--ignore-gpu-blacklist',
+      '--ignore-gpu-blocklist',
       '--metrics-recording-only',
       '--mute-audio',
       '--no-default-browser-check',


### PR DESCRIPTION
Receiving the following error on `5.5.0`:
```
[0121/010200.544134:ERROR:service_utils.cc(157)] --ignore-gpu-blacklist is deprecated and will be removed in 2020Q4, use --ignore-gpu-blocklist instead.
```

According to the change from chromium on this [commit](https://chromium.googlesource.com/chromium/src/+/e660b15416b0afc203b71d854dc38e9bb9f7e509), they were renaming `--ignore-gpu-blacklist` to ` --ignore-gpu-blocklist`