### PR TITLE
devops: added buildbot to test Lambda on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: CI
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12.x
+    - name: Install dependencies
+      run: npm install
+    - name: Build project
+      run: npm run build
+    - name: Test lambda function
+      run: bash buildbots/stub.sh

--- a/buildbots/puppeteer.js
+++ b/buildbots/puppeteer.js
@@ -1,0 +1,27 @@
+const chromium = require('../build/');
+
+exports.handler = async (event, context) => {
+  let browser = null;
+
+  try {
+    const browser = await chromium.puppeteer.launch({
+      executablePath: await chromium.executablePath,
+      defaultViewport: chromium.defaultViewport,
+      args: chromium.args,
+    });
+
+    const page = await browser.newPage();
+    await page.goto(event.url);
+    const data = await page.screenshot();
+    if (data.length === 0) {
+      throw new Error(`Screenshot is empty`);
+    }
+    console.log('Page title: ', await page.title());
+  } catch (error) {
+    throw error;
+  } finally {
+    if (browser !== null) {
+      await browser.close();
+    }
+  }
+};

--- a/buildbots/stub.sh
+++ b/buildbots/stub.sh
@@ -1,0 +1,12 @@
+#/bin/bash
+
+set -e
+
+LOG_FILE="log.txt"
+
+echo "Running Puppeteer lambda function"
+docker run --rm -v "$PWD":/var/task:ro,delegated lambci/lambda:nodejs12.x buildbots/puppeteer.handler '{"url": "https://example.com"}' &> "$LOG_FILE"
+grep -Fq "Example Domain" "$LOG_FILE"
+echo "Sucessfully passed Puppeteer test"
+
+rm "$LOG_FILE"


### PR DESCRIPTION
Hello,

thought something like that would be cool to implement, docs are missing but waiting for the API to be fully clarified beforehand.

Also probably it makes more sense to move maybe Playwright and Puppeteer into the dependencies, because otherwise for users who are using Puppeteer it will say the peer dependency Playwright is missing and vice-versa.

Would be also cool if you could enable GitHub Actions on the repository, they are free and makes us possible to run CI on this repository.

(Tested on one of my repos which uses Vercel which uses AWS Lambda under the hood, works fine, see [here](https://github.com/playwright-community/playwright-community/pull/38/files#diff-541792fbd67c15c903b9b0280de5f01ed356d22500d46ef769dde9e4e8c3685b).)