### PR TITLE
Install devDependencies before make chrome_aws_lambda.zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ The following set of (Linux) commands will create a layer of this package alongs
 ```shell
 git clone --depth=1 https://github.com/alixaxel/chrome-aws-lambda.git && \
 cd chrome-aws-lambda && \
+npm install --only=dev && \
 make chrome_aws_lambda.zip
 ```
 


### PR DESCRIPTION
A small step added in the documentation to avoid unnecessary back and forth configuration of the node environment building an AWS layer.