### PR TITLE
Change dynamic imports to static imports to fix bundling with ESBuild

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -195,9 +195,11 @@ class Chromium {
    * Overloads puppeteer with useful methods and returns the resolved package.
    */
   static get puppeteer(): PuppeteerNode {
-    for (const overload of ['Browser', 'BrowserContext', 'ElementHandle', 'FrameManager', 'Page']) {
-      require(`${__dirname}/puppeteer/lib/${overload}`);
-    }
+    require('./puppeteer/lib/Browser')
+    require('./puppeteer/lib/BrowserContext')
+    require('./puppeteer/lib/ElementHandle')
+    require('./puppeteer/lib/FrameManager')
+    require('./puppeteer/lib/Page')
 
     try {
       return require('puppeteer');


### PR DESCRIPTION
ESBuild does not allow dynamic imports, thus throwing errors when reaching the `require` import changed by this PR. At runtime, the `require` looks for the file in whichever directory we are in (`__dirname`).

The changes proposed were tested and work both for Webpack and ESBuild.