### PR TITLE
Puppeteer@14.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 %.zip:
 	npm install --no-fund --no-package-lock --no-shrinkwrap
 	mkdir -p nodejs/
-	npm install --prefix nodejs/ lambdafs@~2.0.3 puppeteer-core@13.6.0 --no-bin-links --no-fund --no-optional --no-package-lock --no-save --no-shrinkwrap
+	npm install --prefix nodejs/ lambdafs@~2.0.3 puppeteer-core@13.7.0 --no-bin-links --no-fund --no-optional --no-package-lock --no-save --no-shrinkwrap
 	npm pack
 	mkdir -p nodejs/node_modules/chrome-aws-lambda/
 	tar --directory nodejs/node_modules/chrome-aws-lambda/ --extract --file chrome-aws-lambda-*.tgz --strip-components=1

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 %.zip:
 	npm install --no-fund --no-package-lock --no-shrinkwrap
 	mkdir -p nodejs/
-	npm install --prefix nodejs/ lambdafs@~2.0.3 puppeteer-core@13.7.0 --no-bin-links --no-fund --no-optional --no-package-lock --no-save --no-shrinkwrap
+	npm install --prefix nodejs/ lambdafs@~2.0.3 puppeteer-core@14.0.0 --no-bin-links --no-fund --no-optional --no-package-lock --no-save --no-shrinkwrap
 	npm pack
 	mkdir -p nodejs/node_modules/chrome-aws-lambda/
 	tar --directory nodejs/node_modules/chrome-aws-lambda/ --extract --file chrome-aws-lambda-*.tgz --strip-components=1

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 %.zip:
 	npm install --no-fund --no-package-lock --no-shrinkwrap
 	mkdir -p nodejs/
-	npm install --prefix nodejs/ lambdafs@~2.0.3 puppeteer-core@~10.1.0 --no-bin-links --no-fund --no-optional --no-package-lock --no-save --no-shrinkwrap
+	npm install --prefix nodejs/ lambdafs@~2.0.3 puppeteer-core@13.5.0 --no-bin-links --no-fund --no-optional --no-package-lock --no-save --no-shrinkwrap
 	npm pack
 	mkdir -p nodejs/node_modules/chrome-aws-lambda/
 	tar --directory nodejs/node_modules/chrome-aws-lambda/ --extract --file chrome-aws-lambda-*.tgz --strip-components=1

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 %.zip:
 	npm install --no-fund --no-package-lock --no-shrinkwrap
 	mkdir -p nodejs/
-	npm install --prefix nodejs/ lambdafs@~2.0.3 puppeteer-core@14.0.0 --no-bin-links --no-fund --no-optional --no-package-lock --no-save --no-shrinkwrap
+	npm install --prefix nodejs/ lambdafs@~2.0.3 puppeteer-core@14.1.0 --no-bin-links --no-fund --no-optional --no-package-lock --no-save --no-shrinkwrap
 	npm pack
 	mkdir -p nodejs/node_modules/chrome-aws-lambda/
 	tar --directory nodejs/node_modules/chrome-aws-lambda/ --extract --file chrome-aws-lambda-*.tgz --strip-components=1

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 %.zip:
 	npm install --no-fund --no-package-lock --no-shrinkwrap
 	mkdir -p nodejs/
-	npm install --prefix nodejs/ lambdafs@~2.0.3 puppeteer-core@13.5.0 --no-bin-links --no-fund --no-optional --no-package-lock --no-save --no-shrinkwrap
+	npm install --prefix nodejs/ lambdafs@~2.0.3 puppeteer-core@13.6.0 --no-bin-links --no-fund --no-optional --no-package-lock --no-save --no-shrinkwrap
 	npm pack
 	mkdir -p nodejs/node_modules/chrome-aws-lambda/
 	tar --directory nodejs/node_modules/chrome-aws-lambda/ --extract --file chrome-aws-lambda-*.tgz --strip-components=1

--- a/_/amazon/template.yml
+++ b/_/amazon/template.yml
@@ -12,19 +12,8 @@ Resources:
         LayerName: chrome-aws-lambda
         ContentUri: code/
         CompatibleRuntimes:
-          - nodejs10.x
           - nodejs12.x
           - nodejs14.x
-
-  node10:
-    Type: AWS::Serverless::Function
-    Properties:
-      Layers:
-        - !Ref layer
-      Handler: handlers/index.handler
-      Runtime: nodejs10.x
-      Policies:
-        - AWSLambdaBasicExecutionRole
 
   node12:
     Type: AWS::Serverless::Function

--- a/_/amazon/template.yml
+++ b/_/amazon/template.yml
@@ -12,18 +12,7 @@ Resources:
         LayerName: chrome-aws-lambda
         ContentUri: code/
         CompatibleRuntimes:
-          - nodejs12.x
           - nodejs14.x
-
-  node12:
-    Type: AWS::Serverless::Function
-    Properties:
-      Layers:
-        - !Ref layer
-      Handler: handlers/index.handler
-      Runtime: nodejs12.x
-      Policies:
-        - AWSLambdaBasicExecutionRole
 
   node14:
     Type: AWS::Serverless::Function

--- a/_/amazon/template.yml
+++ b/_/amazon/template.yml
@@ -23,3 +23,13 @@ Resources:
       Runtime: nodejs14.x
       Policies:
         - AWSLambdaBasicExecutionRole
+
+  node16:
+    Type: AWS::Serverless::Function
+    Properties:
+      Layers:
+        - !Ref layer
+      Handler: handlers/index.handler
+      Runtime: nodejs16.x
+      Policies:
+        - AWSLambdaBasicExecutionRole

--- a/_/ansible/inventory.ini
+++ b/_/ansible/inventory.ini
@@ -13,4 +13,4 @@ region=us-east-1
 ansible_connection=ssh
 ansible_python_interpreter=auto_silent
 ansible_ssh_private_key_file=ansible.pem
-puppeteer_version=v13.6.0
+puppeteer_version=v13.7.0

--- a/_/ansible/inventory.ini
+++ b/_/ansible/inventory.ini
@@ -4,7 +4,7 @@
 [localhost:vars]
 ansible_connection=local
 ansible_python_interpreter=python
-image=ami-0fc0b1be4effdc8cc
+image=ami-03425aeb2f345b9a9
 region=us-east-1
 
 [aws]
@@ -13,4 +13,4 @@ region=us-east-1
 ansible_connection=ssh
 ansible_python_interpreter=auto_silent
 ansible_ssh_private_key_file=ansible.pem
-puppeteer_version=v13.7.0
+puppeteer_version=v14.0.0

--- a/_/ansible/inventory.ini
+++ b/_/ansible/inventory.ini
@@ -13,4 +13,4 @@ region=us-east-1
 ansible_connection=ssh
 ansible_python_interpreter=auto_silent
 ansible_ssh_private_key_file=ansible.pem
-puppeteer_version=v10.1.0
+puppeteer_version=v13.5.0

--- a/_/ansible/inventory.ini
+++ b/_/ansible/inventory.ini
@@ -13,4 +13,4 @@ region=us-east-1
 ansible_connection=ssh
 ansible_python_interpreter=auto_silent
 ansible_ssh_private_key_file=ansible.pem
-puppeteer_version=v13.5.0
+puppeteer_version=v13.6.0

--- a/_/ansible/inventory.ini
+++ b/_/ansible/inventory.ini
@@ -3,8 +3,8 @@
 
 [localhost:vars]
 ansible_connection=local
-ansible_python_interpreter=python3
-image=ami-0de53d8956e8dcf80
+ansible_python_interpreter=python
+image=ami-0fc0b1be4effdc8cc
 region=us-east-1
 
 [aws]

--- a/_/ansible/inventory.ini
+++ b/_/ansible/inventory.ini
@@ -13,4 +13,4 @@ region=us-east-1
 ansible_connection=ssh
 ansible_python_interpreter=auto_silent
 ansible_ssh_private_key_file=ansible.pem
-puppeteer_version=v14.0.0
+puppeteer_version=v14.1.0

--- a/_/ansible/plays/chromium.yml
+++ b/_/ansible/plays/chromium.yml
@@ -340,22 +340,22 @@
       with_items:
         - "chromium-{{ version.stdout }}.br"
 
-    - name: Archiving SwiftShader
+    - name: Archiving OpenGL ES driver
       shell: |
-        tar --directory /srv/source/chromium/src/out/Headless/swiftshader --create --file swiftshader.tar libEGL.so libGLESv2.so
+        tar --directory /srv/source/chromium/src/out/Headless --create --file swiftshader.tar libEGL.so libGLESv2.so libvk_swiftshader.so libvulkan.so.1 vk_swiftshader_icd.json
       args:
         chdir: /srv/build/chromium
         creates: /srv/build/chromium/swiftshader.tar
         warn: false
 
-    - name: Compressing SwiftShader
+    - name: Compressing OpenGL ES driver
       shell: |
         brotli --best --force swiftshader.tar
       args:
         chdir: /srv/build/chromium
         creates: /srv/build/chromium/swiftshader.tar.br
 
-    - name: Downloading SwiftShader
+    - name: Downloading OpenGL ES driver
       fetch:
         src: /srv/build/chromium/swiftshader.tar.br
         dest: ../../../bin/

--- a/_/ansible/plays/chromium.yml
+++ b/_/ansible/plays/chromium.yml
@@ -86,26 +86,50 @@
     - name: Installing Packages
       become: true
       become_user: root
-      yum:
+      dnf:
         name:
           - "@Development Tools"
-          - binutils
-          - bison
-          - bzip2
+          - alsa-lib-devel
+          - atk-devel
+          - bc
+          - bluez-libs-devel
+          - brlapi-devel
+          - bzip2-devel
+          - cairo-devel
           - cmake
-          - curl
+          - cups-devel
+          - dbus-devel
+          - dbus-glib-devel
           - dbus-x11
-          - flex
-          - git-core
+          - expat-devel
+          - glibc.i686
+          - glibc-langpack-en
           - gperf
-          - patch
+          - gtk3-devel
+          - httpd
+          - java-11-openjdk-devel
+          - libatomic
+          - libcap-devel
+          - libjpeg-devel
+          - libstdc++.i686
+          - libXScrnSaver-devel
+          - libxkbcommon-x11-devel
+          - mod_ssl
+          - ncurses-compat-libs
+          - nspr-devel
+          - nss-devel
+          - pam-devel
+          - pciutils-devel
           - perl
+          - php
+          - php-cli
+          - pulseaudio-libs-devel
+          - python
+          - python-psutil
           - python-setuptools
-          - python3
-          - rpm
           - ruby
-          - subversion
-          - zip
+          - xorg-x11-server-Xvfb
+          - zlib.i686
         state: latest
         update_cache: true
 
@@ -157,26 +181,6 @@
       stat:
         path: /usr/local/bin/brotli
       register: brotli
-
-    - name: Cloning Brotli
-      git:
-        repo: https://github.com/google/brotli.git
-        dest: /srv/source/brotli
-        force: yes
-        update: yes
-      when: brotli.stat.exists != true
-
-    - name: Compiling Brotli
-      become: true
-      become_user: root
-      shell: |
-        ./configure-cmake && \
-        make && \
-        make install
-      args:
-        chdir: /srv/source/brotli
-        creates: /usr/local/bin/brotli
-      when: brotli.stat.exists != true
 
     - name: Cloning Depot Tools
       git:

--- a/_/ansible/plays/chromium.yml
+++ b/_/ansible/plays/chromium.yml
@@ -196,14 +196,14 @@
 
     - name: Fetching Chromium
       shell: |
-        fetch chromium
+        fetch --nohooks chromium
       args:
         chdir: /srv/source/chromium
       when: gclient.stat.exists != true
 
     - name: Resolving Puppeteer Version
       uri:
-        url: "https://raw.githubusercontent.com/GoogleChrome/puppeteer/{{ puppeteer_version | default('main') }}/src/revisions.ts"
+        url: "https://raw.githubusercontent.com/puppeteer/puppeteer/{{ puppeteer_version | default('main') }}/src/revisions.ts"
         return_content: yes
       register: puppeteer_revisions
 
@@ -218,15 +218,15 @@
         return_content: yes
       register: revision
 
-    - name: Checking Out Git Commit
+    - name: Checking Out Chromium revision
       shell: |
-        git checkout {{ revision.json.git_sha }}
+        gclient sync --delete_unversioned_trees --revision {{ revision.json.git_sha }} --with_branch_heads
       args:
-        chdir: /srv/source/chromium/src
+        chdir: /srv/source/chromium
 
-    - name: Synchronizing Chromium
+    - name: Run Chromium hooks
       shell: |
-        gclient sync --with_branch_heads
+        gclient runhooks
       args:
         chdir: /srv/source/chromium
 

--- a/_/ansible/plays/chromium.yml
+++ b/_/ansible/plays/chromium.yml
@@ -278,28 +278,21 @@
         content: |
           import("//build/args/headless.gn")
           blink_symbol_level = 0
-          disable_ftp_support = true
+          dcheck_always_on = false
           disable_histogram_support = false
           enable_basic_print_dialog = false
           enable_basic_printing = true
           enable_keystone_registration_framework = false
           enable_linux_installer = false
           enable_media_remoting = false
-          enable_media_remoting_rpc = false
-          enable_nacl = false
           enable_one_click_signin = false
           ffmpeg_branding = "Chrome"
-          headless_use_embedded_resources = true
-          icu_use_data_file = false
           is_component_build = false
           is_debug = false
           proprietary_codecs = true
           symbol_level = 0
           target_cpu = "x64"
           target_os = "linux"
-          use_bundled_fontconfig = true
-          use_cups = false
-          use_pulseaudio = false
           use_sysroot = true
           v8_target_cpu = "x64"
         dest: /srv/source/chromium/src/out/Headless/args.gn

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chrome-aws-lambda",
   "private": false,
-  "version": "13.6.0",
+  "version": "13.7.0",
   "author": {
     "name": "Alix Axel"
   },
@@ -28,12 +28,12 @@
   },
   "devDependencies": {
     "@types/node": "^10.17.55",
-    "puppeteer-core": "13.6.0",
+    "puppeteer-core": "13.7.0",
     "rimraf": "^3.0.2",
     "typescript": "4.3.2"
   },
   "peerDependencies": {
-    "puppeteer-core": "13.6.0"
+    "puppeteer-core": "13.7.0"
   },
   "bugs": {
     "url": "https://github.com/alixaxel/chrome-aws-lambda/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chrome-aws-lambda",
   "private": false,
-  "version": "10.1.0",
+  "version": "13.5.0",
   "author": {
     "name": "Alix Axel"
   },
@@ -15,7 +15,7 @@
     "typings"
   ],
   "engines": {
-    "node": ">= 10.16"
+    "node": ">= 12"
   },
   "scripts": {
     "build": "rimraf build && tsc -p tsconfig.json",
@@ -28,12 +28,12 @@
   },
   "devDependencies": {
     "@types/node": "^10.17.55",
-    "puppeteer-core": "^10.1.0",
+    "puppeteer-core": "13.5.0",
     "rimraf": "^3.0.2",
     "typescript": "4.3.2"
   },
   "peerDependencies": {
-    "puppeteer-core": "^10.1.0"
+    "puppeteer-core": "13.5.0"
   },
   "bugs": {
     "url": "https://github.com/alixaxel/chrome-aws-lambda/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chrome-aws-lambda",
   "private": false,
-  "version": "14.0.0",
+  "version": "14.1.0",
   "author": {
     "name": "Alix Axel"
   },
@@ -28,12 +28,12 @@
   },
   "devDependencies": {
     "@types/node": "^10.17.55",
-    "puppeteer-core": "14.0.0",
+    "puppeteer-core": "14.1.0",
     "rimraf": "^3.0.2",
     "typescript": "4.3.2"
   },
   "peerDependencies": {
-    "puppeteer-core": "14.0.0"
+    "puppeteer-core": "14.1.0"
   },
   "bugs": {
     "url": "https://github.com/alixaxel/chrome-aws-lambda/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chrome-aws-lambda",
   "private": false,
-  "version": "13.5.0",
+  "version": "13.6.0",
   "author": {
     "name": "Alix Axel"
   },
@@ -28,12 +28,12 @@
   },
   "devDependencies": {
     "@types/node": "^10.17.55",
-    "puppeteer-core": "13.5.0",
+    "puppeteer-core": "13.6.0",
     "rimraf": "^3.0.2",
     "typescript": "4.3.2"
   },
   "peerDependencies": {
-    "puppeteer-core": "13.5.0"
+    "puppeteer-core": "13.6.0"
   },
   "bugs": {
     "url": "https://github.com/alixaxel/chrome-aws-lambda/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chrome-aws-lambda",
   "private": false,
-  "version": "13.7.0",
+  "version": "14.0.0",
   "author": {
     "name": "Alix Axel"
   },
@@ -15,7 +15,7 @@
     "typings"
   ],
   "engines": {
-    "node": ">= 12"
+    "node": ">= 14"
   },
   "scripts": {
     "build": "rimraf build && tsc -p tsconfig.json",
@@ -28,12 +28,12 @@
   },
   "devDependencies": {
     "@types/node": "^10.17.55",
-    "puppeteer-core": "13.7.0",
+    "puppeteer-core": "14.0.0",
     "rimraf": "^3.0.2",
     "typescript": "4.3.2"
   },
   "peerDependencies": {
-    "puppeteer-core": "13.7.0"
+    "puppeteer-core": "14.0.0"
   },
   "bugs": {
     "url": "https://github.com/alixaxel/chrome-aws-lambda/issues"

--- a/source/index.ts
+++ b/source/index.ts
@@ -202,7 +202,7 @@ class Chromium {
 
     try {
       return require('puppeteer');
-    } catch (error) {
+    } catch (error: any) {
       if (error.code !== 'MODULE_NOT_FOUND') {
         throw error;
       }

--- a/source/index.ts
+++ b/source/index.ts
@@ -113,7 +113,8 @@ class Chromium {
       '--no-pings', // https://source.chromium.org/search?q=lang:cpp+symbol:kNoPings&ss=chromium
       '--no-sandbox', // https://source.chromium.org/search?q=lang:cpp+symbol:kNoSandbox&ss=chromium
       '--no-zygote', // https://source.chromium.org/search?q=lang:cpp+symbol:kNoZygote&ss=chromium
-      '--use-gl=swiftshader', // https://source.chromium.org/search?q=lang:cpp+symbol:kUseGl&ss=chromium
+      '--use-gl=angle', // https://chromium.googlesource.com/chromium/src/+/main/docs/gpu/swiftshader.md
+      '--use-angle=swiftshader', // https://chromium.googlesource.com/chromium/src/+/main/docs/gpu/swiftshader.md
       '--window-size=1920,1080', // https://source.chromium.org/search?q=lang:cpp+symbol:kWindowSize&ss=chromium
     ];
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -7,7 +7,7 @@ import { join } from 'path';
 import { PuppeteerNode, Viewport } from 'puppeteer-core';
 import { URL } from 'url';
 
-if (/^AWS_Lambda_nodejs(?:10|12|14)[.]x$/.test(process.env.AWS_EXECUTION_ENV) === true) {
+if (/^AWS_Lambda_nodejs(?:10|12|14|16)[.]x$/.test(process.env.AWS_EXECUTION_ENV) === true) {
   if (process.env.FONTCONFIG_PATH === undefined) {
     process.env.FONTCONFIG_PATH = '/tmp/aws';
   }
@@ -166,7 +166,7 @@ class Chromium {
       LambdaFS.inflate(`${input}/swiftshader.tar.br`),
     ];
 
-    if (/^AWS_Lambda_nodejs(?:10|12|14)[.]x$/.test(process.env.AWS_EXECUTION_ENV) === true) {
+    if (/^AWS_Lambda_nodejs(?:10|12|14|16)[.]x$/.test(process.env.AWS_EXECUTION_ENV) === true) {
       promises.push(LambdaFS.inflate(`${input}/aws.tar.br`));
     }
 

--- a/source/puppeteer/lib/Browser.ts
+++ b/source/puppeteer/lib/Browser.ts
@@ -4,9 +4,9 @@ import { Hook, Prototype } from '../../../typings/chrome-aws-lambda';
 let Super: Prototype<Browser> = null;
 
 try {
-  Super = require('puppeteer/lib/cjs/puppeteer/common/Browser').Browser;
+  Super = require('puppeteer/lib/cjs/puppeteer/common/Browser.js').Browser;
 } catch (error) {
-  Super = require('puppeteer-core/lib/cjs/puppeteer/common/Browser').Browser;
+  Super = require('puppeteer-core/lib/cjs/puppeteer/common/Browser.js').Browser;
 }
 
 Super.prototype.defaultPage = async function (...hooks: Hook[]) {

--- a/source/puppeteer/lib/BrowserContext.ts
+++ b/source/puppeteer/lib/BrowserContext.ts
@@ -4,9 +4,9 @@ import { Hook, Prototype } from '../../../typings/chrome-aws-lambda';
 let Super: Prototype<BrowserContext> = null;
 
 try {
-  Super = require('puppeteer/lib/cjs/puppeteer/common/Browser').BrowserContext;
+  Super = require('puppeteer/lib/cjs/puppeteer/common/Browser.js').BrowserContext;
 } catch (error) {
-  Super = require('puppeteer-core/lib/cjs/puppeteer/common/Browser').BrowserContext;
+  Super = require('puppeteer-core/lib/cjs/puppeteer/common/Browser.js').BrowserContext;
 }
 
 Super.prototype.defaultPage = async function (...hooks: Hook[]) {

--- a/source/puppeteer/lib/ElementHandle.ts
+++ b/source/puppeteer/lib/ElementHandle.ts
@@ -4,9 +4,9 @@ import { KeysOfType, Prototype } from '../../../typings/chrome-aws-lambda';
 let Super: Prototype<ElementHandle> = null;
 
 try {
-  Super = require('puppeteer/lib/cjs/puppeteer/common/JSHandle').ElementHandle;
+  Super = require('puppeteer/lib/cjs/puppeteer/common/JSHandle.js').ElementHandle;
 } catch (error) {
-  Super = require('puppeteer-core/lib/cjs/puppeteer/common/JSHandle').ElementHandle;
+  Super = require('puppeteer-core/lib/cjs/puppeteer/common/JSHandle.js').ElementHandle;
 }
 
 Super.prototype.clear = function () {

--- a/source/puppeteer/lib/FrameManager.ts
+++ b/source/puppeteer/lib/FrameManager.ts
@@ -4,9 +4,9 @@ import { KeysOfType, Prototype } from '../../../typings/chrome-aws-lambda';
 let Super: Prototype<Frame> = null;
 
 try {
-  Super = require('puppeteer/lib/cjs/puppeteer/common/FrameManager').Frame;
+  Super = require('puppeteer/lib/cjs/puppeteer/common/FrameManager.js').Frame;
 } catch (error) {
-  Super = require('puppeteer-core/lib/cjs/puppeteer/common/FrameManager').Frame;
+  Super = require('puppeteer-core/lib/cjs/puppeteer/common/FrameManager.js').Frame;
 }
 
 Super.prototype.clear = function (selector: string) {

--- a/source/puppeteer/lib/Page.ts
+++ b/source/puppeteer/lib/Page.ts
@@ -4,9 +4,9 @@ import { KeysOfType, Prototype } from '../../../typings/chrome-aws-lambda';
 let Super: Prototype<Page> = null;
 
 try {
-  Super = require('puppeteer/lib/cjs/puppeteer/common/Page').Page;
+  Super = require('puppeteer/lib/cjs/puppeteer/common/Page.js').Page;
 } catch (error) {
-  Super = require('puppeteer-core/lib/cjs/puppeteer/common/Page').Page;
+  Super = require('puppeteer-core/lib/cjs/puppeteer/common/Page.js').Page;
 }
 
 Super.prototype.block = function (predicates: string[]) {


### PR DESCRIPTION
This PR updates the build process for chromium and gets puppeteer support up to 14.1.0.

Closes: #240 #248 #258 #254 #242 #274 #275 #276

Notes:
 - Ignore the branch name, I originally created the PR for Puppeteer 13.5.0
 - I am not going to include the binaries in this PR. If you would like to use my binaries or my lambda layer, please see my [latest comments](https://github.com/alixaxel/chrome-aws-lambda/pull/264#issuecomment-1121538536)
 - If you would like to use a scoped npm package that will be kept up to date until this PR is merged, check out [@sparticuz/chrome-aws-lambda](https://www.npmjs.com/package/@sparticuz/chrome-aws-lambda)

Due to some changes in WebGL/SWAngle, this PR does not included the needed fixes for lambdafs. If you need WebGL, please use my scoped package.