### PR TITLE
Fix Webpack and newer typescript version issues

### DIFF
--- a/source/hooks/permissions.ts
+++ b/source/hooks/permissions.ts
@@ -9,7 +9,7 @@ export = async function (page: Page): Promise<Page> {
   const handler = () => {
     let query = window.navigator.permissions.query;
 
-    (Permissions as any).prototype.query = function (parameters: DevicePermissionDescriptor | MidiPermissionDescriptor | PermissionDescriptor | PushPermissionDescriptor) {
+    (Permissions as any).prototype.query = function (parameters: PermissionDescriptor) {
       if (parameters?.name?.length > 0) {
         return Promise.resolve({
           onchange: null,

--- a/source/index.ts
+++ b/source/index.ts
@@ -7,7 +7,7 @@ import { join } from 'path';
 import { PuppeteerNode, Viewport } from 'puppeteer-core';
 import { URL } from 'url';
 
-if (/^AWS_Lambda_nodejs(?:10|12|14)[.]x$/.test(process.env.AWS_EXECUTION_ENV) === true) {
+if (/^AWS_Lambda_nodejs(?:10|12|14|16|18)[.]x$/.test(process.env.AWS_EXECUTION_ENV) === true) {
   if (process.env.FONTCONFIG_PATH === undefined) {
     process.env.FONTCONFIG_PATH = '/tmp/aws';
   }
@@ -165,7 +165,7 @@ class Chromium {
       LambdaFS.inflate(`${input}/swiftshader.tar.br`),
     ];
 
-    if (/^AWS_Lambda_nodejs(?:10|12|14)[.]x$/.test(process.env.AWS_EXECUTION_ENV) === true) {
+    if (/^AWS_Lambda_nodejs(?:10|12|14|16|18)[.]x$/.test(process.env.AWS_EXECUTION_ENV) === true) {
       promises.push(LambdaFS.inflate(`${input}/aws.tar.br`));
     }
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -195,9 +195,11 @@ class Chromium {
    * Overloads puppeteer with useful methods and returns the resolved package.
    */
   static get puppeteer(): PuppeteerNode {
-    for (const overload of ['Browser', 'BrowserContext', 'ElementHandle', 'FrameManager', 'Page']) {
-      require(`${__dirname}/puppeteer/lib/${overload}`);
-    }
+    require('./puppeteer/lib/Browser')
+    require('./puppeteer/lib/BrowserContext')
+    require('./puppeteer/lib/ElementHandle')
+    require('./puppeteer/lib/FrameManager')
+    require('./puppeteer/lib/Page')
 
     try {
       return require('puppeteer');


### PR DESCRIPTION
This continues the work done in #239, based on the puppeteer@12 branch to also add support for newer versions of typescript due to some types removed from `lib.dom.d.ts`.