### PR TITLE
More flexible runtime execution check to support custom runtimes

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -7,7 +7,7 @@ import { join } from 'path';
 import { PuppeteerNode, Viewport } from 'puppeteer-core';
 import { URL } from 'url';
 
-if (/^AWS_Lambda_nodejs(?:10|12|14)[.]x$/.test(process.env.AWS_EXECUTION_ENV) === true) {
+if (/^AWS_Lambda_nodejs/.test(process.env.AWS_EXECUTION_ENV) === true) {
   if (process.env.FONTCONFIG_PATH === undefined) {
     process.env.FONTCONFIG_PATH = '/tmp/aws';
   }
@@ -165,7 +165,7 @@ class Chromium {
       LambdaFS.inflate(`${input}/swiftshader.tar.br`),
     ];
 
-    if (/^AWS_Lambda_nodejs(?:10|12|14)[.]x$/.test(process.env.AWS_EXECUTION_ENV) === true) {
+    if (/^AWS_Lambda_nodejs/.test(process.env.AWS_EXECUTION_ENV) === true) {
       promises.push(LambdaFS.inflate(`${input}/aws.tar.br`));
     }
 


### PR DESCRIPTION
Make AWS Lambda Nodejs regex more tolerant to support custom runtimes, fixes #268 we're happy to prefix our exection env var with `AWS_Lambda_nodejs`, although I guess another option would be an additional env var or argument.